### PR TITLE
Adds a missing space after inline code

### DIFF
--- a/content/posts/2019-04-25-build-an-io-game-part-1.md
+++ b/content/posts/2019-04-25-build-an-io-game-part-1.md
@@ -459,7 +459,7 @@ export function stopCapturingInput() {
 }
 ```
 
-`js›onMouseInput()` and `js›onTouchInput()` are Event Listeners that call `js›updateDirection()` (from `networking.js`) when an input event happens (e.g. the mouse moves). `js›updateDirection()`takes care of messaging the server, which handles the input event and updates the game state accordingly.
+`js›onMouseInput()` and `js›onTouchInput()` are Event Listeners that call `js›updateDirection()` (from `networking.js`) when an input event happens (e.g. the mouse moves). `js›updateDirection()` takes care of messaging the server, which handles the input event and updates the game state accordingly.
 
 ## 7. Client State
 


### PR DESCRIPTION
Not that it matters much, but I think it should be there as the rest of the post inserts whitespace after inlined code.

Very good content, by the way.